### PR TITLE
Add simple Flask prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ python cli.py --mode chat
 ```
 In chat mode, you can have a conversation with the AI assistant by typing messages as the "User." Type 'quit' to exit chat mode.
 
+# __Web Prototype__
+A minimal Flask server allows you to upload a PDF and run Dispute GPT from your browser. Start it with `python app.py` and visit `http://localhost:5000`.
+
 # __Contributing__
 We welcome contributions to Dispute-GPT. If you find any bugs, have feature suggestions/requests, or want to contribute code please create an issue or submit a pull request.
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,36 @@
+import os
+import subprocess
+from flask import Flask, request, render_template
+from werkzeug.utils import secure_filename
+
+UPLOAD_FOLDER = 'uploads'
+ALLOWED_EXTENSIONS = {'pdf'}
+
+app = Flask(__name__)
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+
+def allowed_file(filename):
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        file = request.files.get('file')
+        if file and allowed_file(file.filename):
+            filename = secure_filename(file.filename)
+            save_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+            file.save(save_path)
+
+            process = subprocess.Popen(
+                ['python', 'cli.py', '--mode', 'dispute', '--pdf_path', save_path],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True
+            )
+            output, _ = process.communicate()
+            return render_template('result.html', output=output)
+    return render_template('index.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+flask
+openai
+pandas
+python-dotenv
+colorama
+pdfplumber

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Dispute GPT</title>
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background: #f5f5f7; margin:0; padding:0; display:flex; align-items:center; justify-content:center; height:100vh; }
+.container { background:white; padding:40px; border-radius:12px; box-shadow:0 4px 20px rgba(0,0,0,0.1); text-align:center; }
+input[type=file] { margin-bottom:20px; }
+button { background:#0071e3; color:white; border:none; padding:10px 20px; border-radius:8px; font-size:16px; cursor:pointer; }
+button:hover { background:#0059b3; }
+h1 { margin-bottom:20px; }
+</style>
+</head>
+<body>
+<div class="container">
+    <h1>Dispute GPT</h1>
+    <form method="post" enctype="multipart/form-data">
+        <input type="file" name="file" accept="application/pdf" required>
+        <br>
+        <button type="submit">Run Dispute GPT</button>
+    </form>
+</div>
+</body>
+</html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Dispute GPT Result</title>
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; background:#f5f5f7; margin:0; padding:20px; }
+pre { background:white; padding:20px; border-radius:12px; box-shadow:0 4px 20px rgba(0,0,0,0.1); white-space:pre-wrap; word-break:break-word; }
+a { color:#0071e3; text-decoration:none; }
+</style>
+</head>
+<body>
+<a href="/">&larr; Back</a>
+<pre>{{ output }}</pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal Flask server to run Dispute GPT through the browser
- include Apple-inspired HTML templates for file upload and result
- document how to run the prototype in the README
- add a requirements file for dependencies

## Testing
- `python -m py_compile app.py cli.py test.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684106bc7c648320a0c909846dea2e69