### PR TITLE
Pro plan gating, DocuPost tracking, Send To in both modes, custom let…

### DIFF
--- a/blueprints/disputes.py
+++ b/blueprints/disputes.py
@@ -39,6 +39,18 @@ def free_user_limit_for_dispute(user):
     return False
 
 
+def require_pro_or_business(f):
+    """Decorator: block free users from Pro+ features."""
+    from functools import wraps
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if current_user.plan == 'free':
+            flash("Upgrade to Pro to access this feature.", "error")
+            return redirect(url_for('disputes.index'))
+        return f(*args, **kwargs)
+    return decorated
+
+
 def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in {'pdf'}
 
@@ -258,6 +270,7 @@ def choose_template():
 
 @disputes_bp.route('/prompt-packs', methods=['GET', 'POST'])
 @login_required
+@require_pro_or_business
 def prompt_packs():
     if request.method == 'POST':
         session['prompt_pack'] = request.form['pack_key']
@@ -347,6 +360,8 @@ def manual_mode():
 
 
 @disputes_bp.route('/mail-letter', methods=['GET', 'POST'])
+@login_required
+@require_pro_or_business
 def mail_letter():
     if request.method == 'GET':
         return render_template('mail_letter.html',
@@ -455,6 +470,7 @@ def convert_pdf():
 
 @disputes_bp.route('/dispute-folder')
 @login_required
+@require_pro_or_business
 def dispute_folder():
     logs = DailyLogEntry.query.filter_by(user_id=current_user.id).order_by(DailyLogEntry.timestamp.desc()).all()
     letters = MailedLetter.query.filter_by(user_id=current_user.id).order_by(MailedLetter.created_at.desc()).all()
@@ -464,6 +480,7 @@ def dispute_folder():
 
 @disputes_bp.route('/api/dispute-folder-data')
 @login_required
+@require_pro_or_business
 def dispute_folder_data():
     """Return dispute folder contents as an HTML fragment for the AJAX drawer."""
     logs = DailyLogEntry.query.filter_by(user_id=current_user.id).order_by(DailyLogEntry.timestamp.desc()).all()

--- a/config.py
+++ b/config.py
@@ -60,6 +60,25 @@ def create_app():
             cursor.execute('PRAGMA journal_mode=WAL')
             cursor.close()
 
+        # Auto-add new columns to existing SQLite tables (lightweight migration)
+        db.create_all()
+        with db.engine.connect() as conn:
+            from sqlalchemy import text, inspect
+            inspector = inspect(db.engine)
+            if 'client_dispute_letters' in inspector.get_table_names():
+                existing = [c['name'] for c in inspector.get_columns('client_dispute_letters')]
+                new_cols = {
+                    'docupost_letter_id': 'VARCHAR(100)',
+                    'docupost_cost': 'FLOAT',
+                    'delivery_status': 'VARCHAR(50)',
+                    'mailed_at': 'DATETIME',
+                    'pdf_url': 'VARCHAR(500)',
+                }
+                for col_name, col_type in new_cols.items():
+                    if col_name not in existing:
+                        conn.execute(text(f'ALTER TABLE client_dispute_letters ADD COLUMN {col_name} {col_type}'))
+                conn.commit()
+
     mail.init_app(app)
     login_manager.init_app(app)
 

--- a/models.py
+++ b/models.py
@@ -120,6 +120,12 @@ class ClientDisputeLetter(db.Model):
     letter_text = db.Column(db.Text, nullable=False)
     status = db.Column(db.String(50), default='Draft')  # Draft / Approved / Sent
     template_name = db.Column(db.String(150), nullable=True)
+    pdf_url = db.Column(db.String(500), nullable=True)
+    # DocuPost tracking
+    docupost_letter_id = db.Column(db.String(100), nullable=True)
+    docupost_cost = db.Column(db.Float, nullable=True)
+    delivery_status = db.Column(db.String(50), nullable=True)  # queued / processing / in_transit / delivered / error
+    mailed_at = db.Column(db.DateTime, nullable=True)
     client = db.relationship('Client', backref='letters')
 
 class WorkflowSetting(db.Model):

--- a/services/delivery.py
+++ b/services/delivery.py
@@ -63,7 +63,15 @@ def mail_letter_via_docupost(pdf_url, recipient, sender, mail_options=None):
     try:
         resp = requests.post(DOCUPOST_SENDLETTER_URL, params=params)
         if resp.status_code == 200 and b"<Error>" not in resp.content:
-            return {'success': True, 'response': resp.text}
+            # Parse the JSON response for tracking info
+            result = {'success': True, 'response': resp.text}
+            try:
+                data = resp.json()
+                result['letter_id'] = data.get('letter_id')
+                result['cost'] = data.get('cost')
+            except (ValueError, KeyError):
+                pass  # Response wasn't JSON — still treat as success
+            return result
         else:
             return {'success': False, 'error': resp.text}
     except Exception as e:

--- a/services/pipeline_engine.py
+++ b/services/pipeline_engine.py
@@ -304,6 +304,9 @@ def get_pipeline_status(pipeline_id):
                 'mailed_at': a.mailed_at.isoformat() if a.mailed_at else None,
                 'letter_id': a.letter_id,
                 'letter_status': a.letter.status if a.letter else None,
+                'docupost_letter_id': a.letter.docupost_letter_id if a.letter else None,
+                'docupost_cost': a.letter.docupost_cost if a.letter else None,
+                'delivery_status': a.letter.delivery_status if a.letter else None,
             }
             for a in accounts
         ],
@@ -709,9 +712,19 @@ def handle_delivery(pipeline):
             account.mailed_at = datetime.utcnow()
             account.letter.status = 'Sent'
             account.letter.pdf_url = f"/static/uploads/{client.id}/packages/{package_filename}"
+            account.letter.mailed_at = datetime.utcnow()
+            account.letter.delivery_status = 'queued'
+            # Store DocuPost tracking info
+            if result.get('letter_id'):
+                account.letter.docupost_letter_id = result['letter_id']
+                logger.info(f"DocuPost letter_id: {result['letter_id']}")
+            if result.get('cost'):
+                account.letter.docupost_cost = result['cost']
+                logger.info(f"DocuPost cost: ${result['cost']}")
             sent_count += 1
         else:
             logger.warning(f"Mail failed for account {account.account_number}: {result.get('error')}")
+            account.letter.delivery_status = 'error'
             fail_count += 1
 
         db.session.commit()

--- a/templates/base_header.html
+++ b/templates/base_header.html
@@ -129,8 +129,8 @@
     </div>
   </header>
 
-  {% if current_user.is_authenticated and current_user.plan != 'business' %}
-  <!-- Dispute Folder Toggle -->
+  {% if current_user.is_authenticated and current_user.plan == 'pro' %}
+  <!-- Dispute Folder Toggle (Pro only — free users don't see this) -->
   <button id="openDisputeFolder"
           class="fixed bottom-4 left-4 z-50 glass-btn glass-btn--primary glass-btn--pill shadow-lg">
     Dispute Folder

--- a/templates/business_dashboard.html
+++ b/templates/business_dashboard.html
@@ -222,35 +222,35 @@
             {% endif %}
           </div>
 
+          <!-- Send To (always visible — both modes need this) -->
+          <div class="mb-4">
+            <p class="text-sm font-semibold mb-2" style="color:var(--text-primary);">Send Letters To</p>
+            <div class="grid grid-cols-2 gap-3">
+              <label class="glass-card glass-card--light rounded-xl p-3 cursor-pointer text-center" id="sendto-bureaus-card">
+                <input type="radio" name="send_to" value="bureaus" checked class="sr-only" onchange="updateSendToUI()">
+                <div class="text-lg">&#x1F3E2;</div>
+                <div class="text-xs font-semibold">Bureaus</div>
+              </label>
+              <label class="glass-card glass-card--light rounded-xl p-3 cursor-pointer text-center" id="sendto-creditors-card">
+                <input type="radio" name="send_to" value="creditors" class="sr-only" onchange="updateSendToUI()">
+                <div class="text-lg">&#x1F4BC;</div>
+                <div class="text-xs font-semibold">Creditors</div>
+              </label>
+            </div>
+          </div>
+
+          <!-- Creditor Addresses (hidden by default, shown when Creditors selected) -->
+          <div id="creditorSection" class="hidden mb-4">
+            <p class="text-sm font-semibold mb-2" style="color:var(--text-primary);">Creditor Addresses</p>
+            <div id="creditorRows" class="space-y-2"></div>
+            <button type="button" onclick="addCreditorRow()"
+                    class="glass-btn glass-btn--secondary glass-btn--pill text-xs px-3 py-1 mt-2">
+              + Add Creditor
+            </button>
+          </div>
+
           <!-- Full Auto Config (hidden by default) -->
           <div id="fullAutoConfig" class="hidden space-y-4">
-
-            <!-- Send To -->
-            <div>
-              <p class="text-sm font-semibold mb-2" style="color:var(--text-primary);">Send Letters To</p>
-              <div class="grid grid-cols-2 gap-3">
-                <label class="glass-card glass-card--light rounded-xl p-3 cursor-pointer text-center" id="sendto-bureaus-card">
-                  <input type="radio" name="send_to" value="bureaus" checked class="sr-only" onchange="updateSendToUI()">
-                  <div class="text-lg">&#x1F3E2;</div>
-                  <div class="text-xs font-semibold">Bureaus</div>
-                </label>
-                <label class="glass-card glass-card--light rounded-xl p-3 cursor-pointer text-center" id="sendto-creditors-card">
-                  <input type="radio" name="send_to" value="creditors" class="sr-only" onchange="updateSendToUI()">
-                  <div class="text-lg">&#x1F4BC;</div>
-                  <div class="text-xs font-semibold">Creditors</div>
-                </label>
-              </div>
-            </div>
-
-            <!-- Creditor Addresses (hidden by default) -->
-            <div id="creditorSection" class="hidden">
-              <p class="text-sm font-semibold mb-2" style="color:var(--text-primary);">Creditor Addresses</p>
-              <div id="creditorRows" class="space-y-2"></div>
-              <button type="button" onclick="addCreditorRow()"
-                      class="glass-btn glass-btn--secondary glass-btn--pill text-xs px-3 py-1 mt-2">
-                + Add Creditor
-              </button>
-            </div>
           </div>
 
           <!-- Submit -->
@@ -535,29 +535,28 @@
       config.custom_letter_id = parseInt(clId);
     }
 
-    if (mode === 'full_auto') {
-      config.send_to = document.querySelector('input[name="send_to"]:checked').value;
+    // Send To is always read (visible in both modes)
+    config.send_to = document.querySelector('input[name="send_to"]:checked').value;
 
-      if (config.send_to === 'creditors') {
-        const rows = document.querySelectorAll('#creditorRows > div');
-        if (rows.length === 0) {
-          errEl.textContent = 'Add at least one creditor address.';
+    if (config.send_to === 'creditors') {
+      const rows = document.querySelectorAll('#creditorRows > div');
+      if (rows.length === 0) {
+        errEl.textContent = 'Add at least one creditor address.';
+        errEl.classList.remove('hidden');
+        return;
+      }
+      for (const row of rows) {
+        const name = row.querySelector('.cred-name').value.trim();
+        const addr = row.querySelector('.cred-addr').value.trim();
+        const city = row.querySelector('.cred-city').value.trim();
+        const state = row.querySelector('.cred-state').value.trim();
+        const zip = row.querySelector('.cred-zip').value.trim();
+        if (!name || !addr || !city || !state || !zip) {
+          errEl.textContent = 'All creditor fields are required.';
           errEl.classList.remove('hidden');
           return;
         }
-        for (const row of rows) {
-          const name = row.querySelector('.cred-name').value.trim();
-          const addr = row.querySelector('.cred-addr').value.trim();
-          const city = row.querySelector('.cred-city').value.trim();
-          const state = row.querySelector('.cred-state').value.trim();
-          const zip = row.querySelector('.cred-zip').value.trim();
-          if (!name || !addr || !city || !state || !zip) {
-            errEl.textContent = 'All creditor fields are required.';
-            errEl.classList.remove('hidden');
-            return;
-          }
-          config.creditor_addresses.push({ name, address1: addr, city, state, zip });
-        }
+        config.creditor_addresses.push({ name, address1: addr, city, state, zip });
       }
     }
 

--- a/templates/custom_letters/edit.html
+++ b/templates/custom_letters/edit.html
@@ -1,11 +1,11 @@
 {% extends "base_header.html" %}
 {% block content %}
 <div class="max-w-4xl mx-auto py-10 px-6">
-  <a href="{{ url_for('list_custom_letters') }}"
+  <a href="{{ url_for('business.list_custom_letters') }}"
      class="glass-btn glass-btn--ghost mb-4 inline-flex items-center gap-1 text-sm">← Back to Letters</a>
   <div class="glass-card glass-card--heavy glass-p-lg">
     <h2 class="text-3xl font-bold text-gray-900 mb-6">Edit Custom Letter</h2>
-    <form method="POST" action="{{ url_for('edit_custom_letter', letter_id=letter.id) }}" class="space-y-6">
+    <form method="POST" action="{{ url_for('business.edit_custom_letter', letter_id=letter.id) }}" class="space-y-6">
       <!-- Template Name -->
       <div>
         <label for="name" class="glass-label mb-1">
@@ -49,7 +49,7 @@
       <!-- Actions -->
       <div class="flex justify-end space-x-4">
         <a
-          href="{{ url_for('list_custom_letters') }}"
+          href="{{ url_for('business.list_custom_letters') }}"
           class="glass-btn glass-btn--ghost"
         >
           Cancel

--- a/templates/custom_letters/list.html
+++ b/templates/custom_letters/list.html
@@ -20,7 +20,7 @@
         </button>
       </form>
       <!-- Create from scratch -->
-      <a href="{{ url_for('new_custom_letter') }}"
+      <a href="{{ url_for('business.new_custom_letter') }}"
          class="glass-btn glass-btn--primary inline-flex items-center">
         <svg class="h-5 w-5 mr-2" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
           <path d="M12 4v16m8-8H4" stroke-linecap="round" stroke-linejoin="round"/>
@@ -40,10 +40,10 @@
             <p class="text-sm text-gray-500">Created {{ L.created_at.strftime("%b %d, %Y") }}</p>
           </div>
           <div class="flex space-x-4">
-            <a href="{{ url_for('edit_custom_letter', letter_id=L.id) }}"
+            <a href="{{ url_for('business.edit_custom_letter', letter_id=L.id) }}"
                class="glass-link font-medium">Edit</a>
             <form method="POST"
-                  action="{{ url_for('delete_custom_letter', letter_id=L.id) }}"
+                  action="{{ url_for('business.delete_custom_letter', letter_id=L.id) }}"
                   class="inline">
               <button type="submit"
                       class="glass-btn glass-btn--danger">Delete</button>
@@ -54,7 +54,7 @@
     {% else %}
       <div class="glass-card glass-card--light glass-p text-center text-gray-600">
         You have no custom letters yet.<br>
-        <a href="{{ url_for('new_custom_letter') }}" class="glass-link">
+        <a href="{{ url_for('business.new_custom_letter') }}" class="glass-link">
           Create your first template
         </a>
       </div>

--- a/templates/custom_letters/new.html
+++ b/templates/custom_letters/new.html
@@ -1,7 +1,7 @@
 {% extends "base_header.html" %}
 {% block content %}
 <div class="max-w-3xl mx-auto py-8 px-4">
-  <a href="{{ url_for('list_custom_letters') }}"
+  <a href="{{ url_for('business.list_custom_letters') }}"
      class="glass-btn glass-btn--ghost mb-4 inline-flex items-center gap-1 text-sm">← Back to Letters</a>
   <h1 class="text-2xl font-extrabold text-gray-900 mb-6">
     {% if letter %}
@@ -57,7 +57,7 @@
 
     <!-- Buttons -->
     <div class="flex items-center justify-end space-x-4">
-      <a href="{{ url_for('list_custom_letters') }}"
+      <a href="{{ url_for('business.list_custom_letters') }}"
          class="glass-btn glass-btn--ghost">
         Cancel
       </a>

--- a/templates/view_client.html
+++ b/templates/view_client.html
@@ -138,7 +138,17 @@
             <span class="text-xs" style="color:var(--text-tertiary);">{{ a.account_number }}</span>
             <span class="text-xs" style="color:var(--text-tertiary);">· {{ a.bureau }}</span>
           </div>
-          <div>
+          <div class="flex items-center gap-2">
+            {% if a.docupost_letter_id %}
+              <a href="https://app.docupost.com/letters" target="_blank"
+                 class="glass-badge glass-badge--info text-xs cursor-pointer hover:opacity-80"
+                 title="Track on DocuPost — ID: {{ a.docupost_letter_id }}">
+                &#x1F4EC; {{ a.delivery_status or 'queued' }}
+              </a>
+              {% if a.docupost_cost %}
+              <span class="text-xs" style="color:var(--text-tertiary);">${{ '%.2f'|format(a.docupost_cost) }}</span>
+              {% endif %}
+            {% endif %}
             {% if a.outcome == 'pending' %}
               <span class="glass-badge glass-badge--warning text-xs">Pending</span>
             {% elif a.outcome == 'removed' %}


### PR DESCRIPTION
…ter URL fixes

- Add require_pro_or_business decorator to gate dispute folder, prompt packs, mail letters, and correspondence to Pro/Business users only
- Hide Dispute Folder button from free users entirely in base header
- Store DocuPost letter_id, cost, and delivery_status on ClientDisputeLetter
- Auto-migrate existing SQLite tables to add new tracking columns
- Parse DocuPost JSON response for tracking info in delivery service
- Move Send To (bureaus/creditors) and creditor addresses out of full auto config so they're available in both supervised and full auto modes
- Add DocuPost tracking badges (status + cost) to client view account cards
- Fix broken url_for references in custom letter templates (missing business. prefix)